### PR TITLE
[fix] Correctly handle file uploads

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ class Appetizer {
    */
   flatten(obj) {
     return Object.keys(obj).reduce((memo, key) => {
-      if (this.type(obj[key]) !== 'object') {
+      if (this.type(obj[key]) !== 'object' || key === 'file') {
         memo[key] = obj[key];
         return memo;
       }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -55,6 +55,19 @@ describe('Appetizer', function () {
       assume(flat).deep.equals({ foo: 'bar', bar: 'hi' });
     });
 
+    it('does not flatten file properties', function () {
+      const fs = require('fs');
+      const file = fs.createReadStream(__filename);
+
+      const flat = app.flatten({
+        foo: 'bar',
+        bar: 'hi',
+        file: file
+      });
+
+      assume(flat.file).equals(file);
+    });
+
     it('changes deep stucture to dot notated keys', function () {
       const flat = app.flatten({
         foo: 'bar',


### PR DESCRIPTION
Prevents contents of the `file` which can be `fs.createReadSteam` or `<Buffer>` from being transformed into a dot notation. This way we can actually upload files from the API instead of referencing a remote URL. 

See:
- https://github.com/request/request#multipartform-data-multipart-form-uploads
- https://appetize.io/docs#direct-uploads