### PR TITLE
[fix] Correcty stringify values for the multi-part uploading

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,12 +41,20 @@ class Appetizer {
   flatten(obj) {
     return Object.keys(obj).reduce((memo, key) => {
       if (this.type(obj[key]) !== 'object' || key === 'file') {
-        memo[key] = obj[key];
+        let value = obj[key];
+
+        if (typeof value !== 'object') value = value.toString();
+
+        memo[key] = value;
         return memo;
       }
 
       Object.keys(obj[key]).forEach((name) => {
-        memo[key + '.' + name] = obj[key][name];
+        let value = obj[key][name];
+
+        if (typeof value !== 'object') value = value.toString();
+
+        memo[key + '.' + name] = value;
       });
 
       return memo;

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -68,6 +68,15 @@ describe('Appetizer', function () {
       assume(flat.file).equals(file);
     });
 
+    it('transforms values to string', function () {
+      const flat = app.flatten({
+        foo: 100,
+        bar: true
+      });
+
+      assume(flat).deep.equals({ foo: '100', bar: 'true' });
+    });
+
     it('changes deep stucture to dot notated keys', function () {
       const flat = app.flatten({
         foo: 'bar',


### PR DESCRIPTION
There is some inconsistency in the API when you're using an `url` vs `file` fields because one is uploaded as JSON post request and the other is multi-part request. Apparently sending boolean values does not work intended here. So the following code example used to fail:

```js
app.update(id, {
    file: fs.createReadStream(zipfile),
    fileType: 'zip',
    platform: 'ios',
    disableHome: true
}, fn);
```

And this works for file uploading

```js
app.update(id, {
    file: fs.createReadStream(zipfile),
    fileType: 'zip',
    platform: 'ios',
    disableHome: 'true'
}, fn);
```

This PR fixes that behavior. 